### PR TITLE
feat: add agent slash commands for orchestrator system

### DIFF
--- a/.claude/commands/create-proposal.md
+++ b/.claude/commands/create-proposal.md
@@ -1,0 +1,191 @@
+# Create Proposal
+
+Create a new proposal for the curator to evaluate.
+
+## Proposal Format
+
+Proposals are markdown files with specific metadata:
+
+```markdown
+# Proposal: {Title}
+
+**ID:** PROP-{uuid8}
+**Proposer:** {your_agent_name}
+**Category:** test | refactor | feature | debt | plan-task
+**Complexity:** S | M | L | XL
+**Created:** {ISO8601_timestamp}
+
+## Summary
+One-line description of what this proposes.
+
+## Rationale
+Why this matters. What problem does it solve?
+
+## Complexity Reduction
+(Optional) How this simplifies or unblocks other work.
+
+## Dependencies
+(Optional) What must happen first.
+
+## Enables
+(Optional) What this unblocks.
+
+## Acceptance Criteria
+- [ ] Specific, measurable criterion
+- [ ] Another criterion
+
+## Relevant Files
+- path/to/relevant/file.ts
+- path/to/another/file.py
+```
+
+## Fields
+
+### Category
+- `test` - Test quality improvements (coverage, flaky tests, assertions)
+- `refactor` - Code structure improvements (simplification, patterns)
+- `feature` - New functionality
+- `debt` - Technical debt reduction
+- `plan-task` - Tasks extracted from project plans
+
+### Complexity
+- `S` - Few hours, single file
+- `M` - Day or two, few files
+- `L` - Several days, multiple components
+- `XL` - Week+, architectural changes
+
+## Writing Good Proposals
+
+### Title
+- Be specific: "Add retry logic to API client"
+- Not vague: "Improve error handling"
+
+### Summary
+- One clear sentence
+- What will change, not how
+
+### Rationale
+- Explain WHY this matters
+- Connect to project goals
+- Quantify impact if possible
+
+### Acceptance Criteria
+- Specific and verifiable
+- Each criterion independently testable
+- Include edge cases
+
+### Relevant Files
+- List files that will be affected
+- Helps curator detect conflicts
+- Helps implementer scope work
+
+## Example
+
+```markdown
+# Proposal: Add retry logic to API client
+
+**ID:** PROP-a1b2c3d4
+**Proposer:** architect
+**Category:** refactor
+**Complexity:** M
+**Created:** 2024-01-15T10:30:00Z
+
+## Summary
+Add exponential backoff retry logic to all external API calls.
+
+## Rationale
+Currently, transient network failures cause immediate errors. Adding retry
+logic will improve reliability and reduce failed operations by ~80% based
+on error logs showing most failures are transient.
+
+## Complexity Reduction
+Will allow us to remove ad-hoc retry logic in 5 different places, replacing
+it with a single, well-tested implementation.
+
+## Dependencies
+None - this is a standalone improvement.
+
+## Enables
+- Unblocks the batch processing feature (needs reliable API calls)
+- Reduces on-call burden from transient failures
+
+## Acceptance Criteria
+- [ ] All external API calls use retry wrapper
+- [ ] Exponential backoff with jitter (100ms base, 5 max retries)
+- [ ] Retries are logged for observability
+- [ ] Non-retryable errors (4xx) fail immediately
+- [ ] Unit tests cover retry behavior
+
+## Relevant Files
+- src/api/client.ts
+- src/api/retry.ts (new)
+- src/services/external-service.ts
+```
+
+## Creating the Proposal
+
+After analyzing the codebase, create the proposal by writing a markdown file directly.
+
+### Step 1: Generate filename with timestamp
+
+Generate a timestamped filename for the proposal:
+
+```bash
+TIMESTAMP=$(date +%Y-%m-%d-%H%M)
+FILENAME="${TIMESTAMP}-refactor-proposal.md"
+echo $FILENAME
+```
+
+Use appropriate suffix based on proposal type:
+- `-refactor-proposal.md` for refactoring
+- `-implementation-proposal.md` for new features
+- `-question.md` for questions needing user input
+- `-decision.md` for architectural decisions
+
+### Step 2: Write the proposal file
+
+Write the proposal to `project-management/human-inbox/{FILENAME}`:
+
+```bash
+# Ensure the directory exists
+mkdir -p project-management/human-inbox
+
+# Write the proposal (replace with your content)
+cat > project-management/human-inbox/2024-01-15-1030-refactor-proposal.md << 'EOF'
+# Proposal: Add retry logic to API client
+
+**Proposer:** architect
+**Category:** refactor
+**Complexity:** M
+**Created:** 2024-01-15T10:30:00Z
+
+## Summary
+Add exponential backoff retry logic to all external API calls.
+
+## Rationale
+Currently, transient network failures cause immediate errors...
+
+## Acceptance Criteria
+- [ ] All external API calls use retry wrapper
+- [ ] Exponential backoff with jitter
+- [ ] Unit tests cover retry behavior
+
+## Relevant Files
+- src/api/client.ts
+- src/services/external-service.ts
+EOF
+```
+
+### Important Notes
+
+- Use your agent name from the `AGENT_NAME` environment variable as the Proposer
+- Use the current timestamp in ISO8601 format for Created
+- The file must be placed in `project-management/human-inbox/`
+- The filename format is `{YYYY-MM-DD-HHMM}-{type}-proposal.md`
+
+## After Creation
+
+The proposal will be:
+1. Placed in `project-management/human-inbox/`
+2. Reviewed by the user via their `/human-inbox` command
+3. Approved (moved to docs/ and/or tasks created) or rejected with feedback

--- a/.claude/commands/create-task.md
+++ b/.claude/commands/create-task.md
@@ -1,0 +1,129 @@
+# Create Task
+
+Create a well-formed task for the orchestrator queue.
+
+## Task Format
+
+Tasks are markdown files with specific metadata fields:
+
+```markdown
+# [TASK-{uuid8}] {Title}
+
+ROLE: implement | test | review
+PRIORITY: P0 | P1 | P2
+BRANCH: {base_branch}
+CREATED: {ISO8601_timestamp}
+CREATED_BY: {agent_name}
+
+## Context
+{Background and motivation}
+
+## Acceptance Criteria
+- [ ] {Specific, measurable criterion}
+- [ ] {Another criterion}
+```
+
+## Fields
+
+### ROLE
+- `implement` - Code changes, new features, bug fixes
+- `test` - Test writing, test running, coverage improvements
+- `review` - Code review, security audit
+
+### PRIORITY
+- `P0` - Critical/urgent (security issues, broken builds)
+- `P1` - High priority (important features, significant bugs)
+- `P2` - Normal priority (improvements, minor issues)
+
+### BRANCH
+The base branch to work from:
+- `main` - Most tasks
+- `feature/xyz` - Tasks that build on in-progress features
+- `hotfix/xyz` - Urgent fixes
+
+## Writing Good Tasks
+
+### Title
+- Be specific: "Add rate limiting to /api/auth endpoints"
+- Not vague: "Improve security"
+
+### Context
+- Explain WHY this task matters
+- Provide background for someone unfamiliar
+- Link to related issues/PRs if relevant
+
+### Acceptance Criteria
+- Specific and measurable
+- Each criterion independently verifiable
+- Include edge cases that must be handled
+
+## Example Task
+
+```markdown
+# [TASK-a1b2c3d4] Add input validation to user registration
+
+ROLE: implement
+PRIORITY: P1
+BRANCH: main
+CREATED: 2024-01-15T10:30:00Z
+CREATED_BY: pm-agent
+
+## Context
+The user registration endpoint currently accepts any input without validation.
+This could lead to invalid data in the database and potential security issues.
+Related: Issue #42
+
+## Acceptance Criteria
+- [ ] Email addresses are validated for proper format
+- [ ] Passwords require minimum 8 characters, 1 number, 1 special char
+- [ ] Username is alphanumeric, 3-20 characters
+- [ ] Validation errors return 400 with specific error messages
+- [ ] Unit tests cover all validation rules
+```
+
+## Creating the Task
+
+### Step 1: Generate a unique ID
+
+```bash
+TASK_ID="TASK-$(openssl rand -hex 4)"
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+echo "Creating ${TASK_ID}"
+```
+
+### Step 2: Write the task file
+
+```bash
+mkdir -p .orchestrator/shared/queue/incoming
+
+cat > ".orchestrator/shared/queue/incoming/${TASK_ID}.md" << EOF
+# [${TASK_ID}] Add input validation to user registration
+
+ROLE: implement
+PRIORITY: P1
+BRANCH: main
+CREATED: ${TIMESTAMP}
+CREATED_BY: ${AGENT_NAME}
+
+## Context
+
+The user registration endpoint currently accepts any input without validation.
+This could lead to invalid data in the database and potential security issues.
+Related: Issue #42
+
+## Acceptance Criteria
+- [ ] Email addresses are validated for proper format
+- [ ] Passwords require minimum 8 characters, 1 number, 1 special char
+- [ ] Username is alphanumeric, 3-20 characters
+- [ ] Validation errors return 400 with specific error messages
+- [ ] Unit tests cover all validation rules
+EOF
+```
+
+## After Creation
+
+The task will be:
+1. Placed in `.orchestrator/shared/queue/incoming/`
+2. Available for claiming by agents with matching roles
+3. Moved to `claimed/` when an agent picks it up
+4. Moved to `done/` or `failed/` when complete

--- a/.claude/commands/defer-proposal.md
+++ b/.claude/commands/defer-proposal.md
@@ -1,0 +1,114 @@
+# Defer Proposal
+
+Defer a proposal for later consideration.
+
+## Usage
+
+```
+/defer-proposal PROP-abc12345 "Reason for deferral"
+```
+
+## What Happens
+
+1. Proposal is moved from `proposals/active/` to `proposals/deferred/`
+2. Deferral reason is appended to the proposal file
+3. The proposal can be reactivated later
+
+## When to Defer
+
+Defer a proposal when:
+
+- It's a good idea but the timing isn't right
+- It's blocked by dependencies that aren't complete
+- The task queue is full (backpressure)
+- It's part of a conflict being escalated
+- The project is in a phase where this doesn't fit
+
+## Deferral vs Rejection
+
+**Defer** when:
+- The idea is valid
+- It should be done eventually
+- Circumstances will change to make it appropriate
+
+**Reject** when:
+- The idea itself is problematic
+- The approach is wrong
+- It shouldn't be done at all
+
+## Common Deferral Reasons
+
+### Backpressure
+```
+The task queue is currently at capacity (15/20 tasks pending).
+Deferring until capacity frees up. This is a good proposal and
+will be reconsidered soon.
+```
+
+### Dependencies
+```
+This depends on the authentication refactor (TASK-xyz) which is
+still in progress. Deferring until that work is complete.
+```
+
+### Project Phase
+```
+We're currently in stabilization mode before the v2.0 release.
+Deferring new features until after the release (expected 2024-02-15).
+```
+
+### Conflict Escalation
+```
+This proposal conflicts with PROP-def456. Both have been deferred
+and escalated to the project owner for a decision.
+```
+
+### Resource Constraints
+```
+All implementers are currently assigned to high-priority work.
+Deferring until an implementer becomes available.
+```
+
+## Implementation
+
+```bash
+PROP_ID="PROP-abc12345"
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Move to deferred directory
+mkdir -p .orchestrator/shared/proposals/deferred
+mv ".orchestrator/shared/proposals/active/${PROP_ID}.md" \
+   ".orchestrator/shared/proposals/deferred/${PROP_ID}.md"
+
+# Append deferral info
+cat >> ".orchestrator/shared/proposals/deferred/${PROP_ID}.md" << EOF
+
+---
+## Deferral
+
+**Deferred:** ${TIMESTAMP}
+
+### Reason
+
+Task queue at capacity. Will reconsider when queue clears.
+EOF
+```
+
+## After Deferral
+
+- The proposal moves to `proposals/deferred/`
+- It remains there until manually reactivated
+- Periodic review of deferred proposals is recommended
+
+## Reactivating Deferred Proposals
+
+To move a deferred proposal back to active:
+
+```bash
+PROP_ID="PROP-abc12345"
+
+mv ".orchestrator/shared/proposals/deferred/${PROP_ID}.md" \
+   ".orchestrator/shared/proposals/active/${PROP_ID}.md"
+```
+
+This moves it back to `proposals/active/` for re-evaluation.

--- a/.claude/commands/escalate-conflict.md
+++ b/.claude/commands/escalate-conflict.md
@@ -1,0 +1,149 @@
+# Escalate Conflict
+
+Escalate conflicting proposals to the project owner.
+
+## Usage
+
+```
+/escalate-conflict PROP-abc12345 PROP-def67890 "Description of conflict"
+```
+
+## What Happens
+
+1. A warning message is created for the project owner
+2. Both proposals are deferred pending resolution
+3. The message includes both proposals and the conflict details
+
+## When to Escalate
+
+Escalate when:
+
+- Two proposals modify the same files in incompatible ways
+- Proposals represent different architectural directions
+- A refactor conflicts with a feature implementation
+- You cannot determine which proposal should take priority
+- The decision requires domain knowledge you don't have
+
+## What NOT to Escalate
+
+Don't escalate:
+- Simple priority decisions (just promote the higher-priority one)
+- Proposals that can be sequenced (do one first, then the other)
+- Duplicates (just reject the duplicate)
+
+## Conflict Types
+
+### Same Files
+```
+Both proposals modify src/api/client.ts:
+- PROP-abc: Wants to add retry logic
+- PROP-def: Wants to refactor to use a different HTTP library
+
+These cannot proceed simultaneously. One must complete first, or
+they need to be combined into a single approach.
+```
+
+### Architectural Direction
+```
+These proposals represent different approaches:
+- PROP-abc: Add caching at the API layer
+- PROP-def: Add caching at the database layer
+
+Both solve the same problem differently. The project owner should
+decide the preferred approach.
+```
+
+### Feature vs Refactor
+```
+- PROP-abc: Add new payment method (feature)
+- PROP-def: Refactor payment module for simplicity (refactor)
+
+The refactor would change interfaces the feature depends on.
+Need to decide: feature first then refactor, or refactor first?
+```
+
+## Implementation
+
+### Step 1: Defer both proposals
+
+```bash
+PROP1="PROP-abc12345"
+PROP2="PROP-def67890"
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# Defer proposal 1
+mkdir -p .orchestrator/shared/proposals/deferred
+mv ".orchestrator/shared/proposals/active/${PROP1}.md" \
+   ".orchestrator/shared/proposals/deferred/${PROP1}.md"
+cat >> ".orchestrator/shared/proposals/deferred/${PROP1}.md" << EOF
+
+---
+## Deferral
+
+**Deferred:** ${TIMESTAMP}
+
+### Reason
+
+Deferred pending conflict resolution with ${PROP2}.
+EOF
+
+# Defer proposal 2
+mv ".orchestrator/shared/proposals/active/${PROP2}.md" \
+   ".orchestrator/shared/proposals/deferred/${PROP2}.md"
+cat >> ".orchestrator/shared/proposals/deferred/${PROP2}.md" << EOF
+
+---
+## Deferral
+
+**Deferred:** ${TIMESTAMP}
+
+### Reason
+
+Deferred pending conflict resolution with ${PROP1}.
+EOF
+```
+
+### Step 2: Create escalation message
+
+```bash
+mkdir -p .orchestrator/messages
+
+cat > ".orchestrator/messages/warning-$(date +%Y%m%d-%H%M%S)-conflict.md" << 'EOF'
+# ⚠️ Conflict: PROP-abc12345 vs PROP-def67890
+
+**Type:** warning
+**Time:** 2024-01-15T14:30:00
+**From:** curator
+
+---
+
+Two proposals appear to conflict:
+
+## Proposal 1: Add retry logic to API client
+ID: PROP-abc12345
+Category: refactor
+
+## Proposal 2: Replace HTTP library
+ID: PROP-def67890
+Category: refactor
+
+## Conflict
+
+Both proposals modify src/api/client.ts in incompatible ways.
+
+## Options
+1. Approve proposal 1, reject proposal 2
+2. Approve proposal 2, reject proposal 1
+3. Combine into a single approach
+4. Sequence them (specify order)
+
+Both proposals have been deferred pending your decision.
+EOF
+```
+
+## After Escalation
+
+- Both proposals are in `proposals/deferred/`
+- A message is in `.orchestrator/messages/`
+- The user's Claude session will show the message
+- Once resolved, the owner should reactivate the chosen proposal(s)

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -1,0 +1,59 @@
+# Implementation Guide
+
+You are implementing a feature or fix. Follow these guidelines:
+
+## Before You Start
+
+1. **Read the task thoroughly** - understand all acceptance criteria
+2. **Explore the codebase** - find related code, understand patterns
+3. **Plan your approach** - think before coding
+
+## Implementation Standards
+
+### Code Quality
+- Follow existing code patterns and conventions
+- Keep functions/methods focused and small
+- Use meaningful names for variables and functions
+- Add comments only where logic isn't self-evident
+
+### Error Handling
+- Handle errors appropriately for the context
+- Don't swallow errors silently
+- Provide helpful error messages
+
+### Security
+- Never hardcode secrets or credentials
+- Validate and sanitize inputs at boundaries
+- Be aware of OWASP Top 10 vulnerabilities
+
+## Git Workflow
+
+### Commits
+- Make atomic commits (one logical change per commit)
+- Write clear commit messages:
+  ```
+  type: brief description
+
+  More details if needed.
+  ```
+- Types: feat, fix, refactor, test, docs, chore
+
+### Commit Message Examples
+- `feat: add user authentication endpoint`
+- `fix: handle null pointer in payment processor`
+- `refactor: extract validation logic to helper`
+- `test: add unit tests for order service`
+
+## Testing
+
+- Write tests for new functionality
+- Ensure existing tests still pass
+- Test edge cases and error conditions
+- Run the test suite before considering work complete
+
+## When You're Done
+
+1. Review your changes (`git diff`)
+2. Ensure all tests pass
+3. Make final commit if needed
+4. Summarize what you implemented

--- a/.claude/commands/promote-proposal.md
+++ b/.claude/commands/promote-proposal.md
@@ -1,0 +1,132 @@
+# Promote Proposal
+
+Move a proposal from the active queue to the task queue.
+
+## Usage
+
+```
+/promote-proposal PROP-abc12345
+```
+
+## What Happens
+
+1. Proposal is moved from `proposals/active/` to `proposals/promoted/`
+2. A corresponding task is created in `queue/incoming/`
+3. The proposal is marked with promotion timestamp
+
+## When to Promote
+
+Promote a proposal when:
+
+- It aligns with current project priorities
+- It is well-scoped and actionable
+- All dependencies are met
+- There are no unresolved conflicts with other proposals
+- The task queue has capacity (backpressure check)
+
+## Promotion Criteria
+
+Before promoting, verify:
+
+### Priority Alignment
+- Does this support current project goals?
+- Is now the right time for this work?
+
+### Scope
+- Is the proposal specific enough to implement?
+- Are acceptance criteria clear and testable?
+
+### Dependencies
+- Are prerequisite tasks complete?
+- Are required resources available?
+
+### Conflicts
+- Does this conflict with other active proposals?
+- Does it overlap with work in progress?
+
+## Implementation
+
+### Step 1: Read the proposal and generate task ID
+
+```bash
+PROP_ID="PROP-abc12345"
+TASK_ID="TASK-$(openssl rand -hex 4)"
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+```
+
+### Step 2: Create the task file
+
+```bash
+mkdir -p .orchestrator/shared/queue/incoming
+
+cat > ".orchestrator/shared/queue/incoming/${TASK_ID}.md" << 'EOF'
+# [TASK-abc12345] Add retry logic to API client
+
+ROLE: implement
+PRIORITY: P1
+BRANCH: main
+CREATED: 2024-01-15T10:30:00Z
+CREATED_BY: curator
+FROM_PROPOSAL: PROP-abc12345
+
+## Context
+
+Add exponential backoff retry logic to all external API calls.
+
+Currently, transient network failures cause immediate errors. Adding retry
+logic will improve reliability.
+
+## Acceptance Criteria
+- [ ] All external API calls use retry wrapper
+- [ ] Exponential backoff with jitter
+- [ ] Unit tests cover retry behavior
+
+## Relevant Files
+- src/api/client.ts
+- src/services/external-service.ts
+EOF
+```
+
+### Step 3: Move proposal to promoted
+
+```bash
+mkdir -p .orchestrator/shared/proposals/promoted
+mv ".orchestrator/shared/proposals/active/${PROP_ID}.md" \
+   ".orchestrator/shared/proposals/promoted/${PROP_ID}.md"
+
+# Append promotion info
+cat >> ".orchestrator/shared/proposals/promoted/${PROP_ID}.md" << EOF
+
+---
+**Promoted:** ${TIMESTAMP}
+**Task:** ${TASK_ID}
+EOF
+```
+
+## Task Mapping
+
+When creating the task from a proposal:
+
+| Proposal Field | Task Field |
+|----------------|------------|
+| title | title |
+| rationale | context |
+| acceptance_criteria | acceptance_criteria |
+| category → implement/test/review | role |
+| complexity → P0/P1/P2 | priority |
+
+### Category to Role Mapping
+- `test` → role: test
+- `refactor`, `feature`, `debt` → role: implement
+- `plan-task` → depends on content
+
+### Complexity to Priority Mapping
+- `S`, `M` with high value → P1
+- `L`, `XL` or lower value → P2
+- Urgent/blocking issues → P0
+
+## After Promotion
+
+- The proposal file moves to `proposals/promoted/`
+- The task appears in `queue/incoming/`
+- An implementer will claim and work on it

--- a/.claude/commands/record-check.md
+++ b/.claude/commands/record-check.md
@@ -1,0 +1,159 @@
+# Record Check Result
+
+Record the result of a gatekeeper check on a PR.
+
+## Usage
+
+After completing your review of the PR, use this skill to record your findings by writing a markdown file.
+
+## Check Statuses
+
+- `passed` - PR passes this check with no issues
+- `failed` - PR has issues that must be fixed before merging
+- `warning` - PR has minor issues but can proceed with caution
+
+## Recording a Check Result
+
+### Step 1: Get PR number and check name
+
+The PR number is in the `PR_NUMBER` environment variable.
+Your focus area (check name) is in the `AGENT_FOCUS` environment variable.
+
+### Step 2: Write the check result file
+
+Write the result to `.orchestrator/shared/prs/PR-{number}/checks/{check_name}.md`:
+
+```bash
+# Get values from environment
+PR_NUMBER="${PR_NUMBER}"
+CHECK_NAME="${AGENT_FOCUS}"
+
+# Ensure the directory exists
+mkdir -p ".orchestrator/shared/prs/PR-${PR_NUMBER}/checks"
+
+# Write the check result
+cat > ".orchestrator/shared/prs/PR-${PR_NUMBER}/checks/${CHECK_NAME}.md" << 'EOF'
+# ✅ Lint Check
+
+**Status:** passed
+**Time:** 2024-01-15T10:30:00Z
+**Summary:** All lint checks pass, no style issues found.
+
+## Details
+
+Analyzed 15 modified files for lint and style issues.
+
+### Findings
+- No ESLint errors
+- No TypeScript type issues
+- Formatting matches project standards
+EOF
+```
+
+## Check File Format
+
+```markdown
+# {emoji} {Check Name} Check
+
+**Status:** passed | failed | warning
+**Time:** {ISO8601_timestamp}
+**Summary:** {one-line summary}
+
+## Details
+
+{detailed markdown report}
+
+## Issues
+
+- **{severity}** `{file}:{line}`: {message}
+- **{severity}** `{file}:{line}`: {message}
+```
+
+### Status Emojis
+- `✅` for passed
+- `❌` for failed
+- `⚠️` for warning
+
+## Guidelines
+
+### For Passed Checks
+- Briefly confirm what was verified
+- Note any edge cases that were considered
+
+### For Failed Checks
+- Be specific about what failed and why
+- Provide actionable feedback for fixing
+- Reference specific files and lines
+- Suggest solutions when possible
+
+### For Warnings
+- Explain why it's a warning not a failure
+- Indicate if it should block merge or not
+- Suggest improvements for future PRs
+
+## Example: Failed Check
+
+```bash
+cat > ".orchestrator/shared/prs/PR-${PR_NUMBER}/checks/tests.md" << 'EOF'
+# ❌ Tests Check
+
+**Status:** failed
+**Time:** 2024-01-15T10:30:00Z
+**Summary:** 2 test failures in auth module
+
+## Details
+
+## Test Results
+
+**Total:** 127 tests
+**Passed:** 125
+**Failed:** 2
+
+### Failures
+
+1. `test_login_invalid_password` - Expected error message changed
+2. `test_session_expiry` - Timeout assertion off by 1 second
+
+### Recommendation
+The test expectations need to be updated to match the new behavior.
+
+## Issues
+
+- **error** `tests/auth/test_login.py:45`: Expected error message 'Invalid password' but got 'Incorrect password'
+- **error** `tests/auth/test_session.py:78`: Session expiry assertion failed: expected 3600, got 3601
+EOF
+```
+
+## Example: Passed with Notes
+
+```bash
+cat > ".orchestrator/shared/prs/PR-${PR_NUMBER}/checks/architecture.md" << 'EOF'
+# ✅ Architecture Check
+
+**Status:** passed
+**Time:** 2024-01-15T10:30:00Z
+**Summary:** Architecture changes are well-structured
+
+## Details
+
+### Changes Reviewed
+- New service layer for user management
+- Updated dependency injection patterns
+- Modified API boundaries
+
+### Assessment
+The changes follow established patterns and maintain proper separation of concerns.
+The new UserService correctly implements the Repository pattern.
+
+### Recommendations (Non-blocking)
+- Consider adding interface documentation for the new service
+- The service could benefit from caching in future iterations
+EOF
+```
+
+## After Recording
+
+The check result will be:
+1. Stored in `.orchestrator/shared/prs/PR-{number}/checks/`
+2. Aggregated by the gatekeeper coordinator
+3. Used to determine if PR passes or needs fixes

--- a/.claude/commands/reject-proposal.md
+++ b/.claude/commands/reject-proposal.md
@@ -1,0 +1,120 @@
+# Reject Proposal
+
+Reject a proposal with constructive feedback.
+
+## Usage
+
+```
+/reject-proposal PROP-abc12345 "Reason for rejection"
+```
+
+## What Happens
+
+1. Proposal is moved from `proposals/active/` to `proposals/rejected/`
+2. Rejection reason is appended to the proposal file
+3. The proposer will see this feedback on their next run
+
+## When to Reject
+
+Reject a proposal when:
+
+- It's fundamentally flawed in approach
+- It's out of scope for the project
+- It duplicates existing or in-progress work
+- It conflicts with project direction
+- It's too vague to be actionable (after consideration)
+
+## Rejection vs Deferral
+
+**Reject** when:
+- The idea itself is problematic
+- It should NOT be done (now or later)
+- The proposer needs to rethink their approach
+
+**Defer** when:
+- It's a good idea but wrong timing
+- It's blocked by dependencies
+- The queue is full (backpressure)
+
+## Writing Good Feedback
+
+The proposer will use your feedback to improve. Be:
+
+### Specific
+- "This is too vague"
+- "The acceptance criteria don't specify what error handling is needed"
+
+### Constructive
+- "This won't work"
+- "This approach won't work because X. Consider Y instead."
+
+### Actionable
+- "Not aligned with priorities"
+- "We're currently focused on stability. Resubmit after the v2.0 release."
+
+### Encouraging when appropriate
+- "Good observation about the flaky tests. Consider splitting this into separate proposals for each test file."
+
+## Example Rejections
+
+### Too Broad
+```
+This proposal covers too much ground. "Improve error handling across the app"
+could be a month of work. Consider:
+1. Identify the top 3 error-prone areas from logs
+2. Create separate proposals for each
+3. Start with the highest-impact area
+```
+
+### Wrong Approach
+```
+Adding retry logic at the HTTP layer will cause issues with non-idempotent
+operations. Instead, consider:
+1. Adding retries only for GET requests
+2. Using a circuit breaker pattern for other methods
+3. Making the retry policy configurable per endpoint
+```
+
+### Duplicate Work
+```
+This is already being addressed in PR #142 which adds the same functionality.
+Check open PRs before proposing to avoid duplicates.
+```
+
+## Implementation
+
+```bash
+PROP_ID="PROP-abc12345"
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+REJECTED_BY="${AGENT_NAME}"
+
+# Move to rejected directory
+mkdir -p .orchestrator/shared/proposals/rejected
+mv ".orchestrator/shared/proposals/active/${PROP_ID}.md" \
+   ".orchestrator/shared/proposals/rejected/${PROP_ID}.md"
+
+# Append rejection info
+cat >> ".orchestrator/shared/proposals/rejected/${PROP_ID}.md" << EOF
+
+---
+## Rejection
+
+**Rejected:** ${TIMESTAMP}
+**Rejected By:** ${REJECTED_BY}
+
+### Reason
+
+This proposal is too broad. "Comprehensive logging" could mean many things.
+
+Consider:
+1. Split into smaller, focused proposals
+2. Start with error logging specifically
+3. Specify the logging framework to use
+EOF
+```
+
+## After Rejection
+
+- The proposal moves to `proposals/rejected/`
+- The proposer sees the feedback on their next run
+- They may resubmit an improved version

--- a/.claude/commands/review-rejections.md
+++ b/.claude/commands/review-rejections.md
@@ -1,0 +1,107 @@
+# Review Rejections
+
+Review your previously rejected proposals with feedback.
+
+## Purpose
+
+Before creating new proposals, you should review why previous proposals
+were rejected. This helps you:
+
+1. Avoid repeating the same mistakes
+2. Understand project priorities better
+3. Refine your proposals to be more likely to succeed
+
+## What You'll See
+
+Rejected proposals include feedback from the curator:
+
+```markdown
+# Proposal: Add comprehensive logging
+
+**ID:** PROP-abc12345
+**Proposer:** architect
+**Category:** refactor
+**Complexity:** L
+**Created:** 2024-01-10T10:30:00Z
+
+...original proposal content...
+
+---
+## Rejection
+
+**Rejected:** 2024-01-11T14:20:00Z
+**Rejected By:** curator
+
+### Reason
+
+This proposal is too broad. "Comprehensive logging" could mean many things.
+Consider:
+1. Split into smaller, focused proposals (error logging, audit logging, etc.)
+2. Start with one specific area that has the highest impact
+3. Specify what logging framework to use
+
+Also, we're currently focused on stability - new features should wait.
+```
+
+## Using the Feedback
+
+### Common Rejection Reasons
+
+**Too Broad**
+- Split into smaller proposals
+- Focus on one specific area
+
+**Wrong Timing**
+- Wait for the right project phase
+- Check if dependencies are met
+
+**Duplicates Existing Work**
+- Check the task queue first
+- Look at open PRs
+
+**Poorly Defined**
+- Add specific acceptance criteria
+- Include relevant files
+- Explain rationale more clearly
+
+**Conflicts with Priorities**
+- Align with current project goals
+- Check with project owner first
+
+### Before Re-proposing
+
+If you want to re-submit a similar idea:
+
+1. **Address all feedback points** - Don't ignore the curator's comments
+2. **Check if the issue still exists** - Maybe it was fixed another way
+3. **Verify timing is better** - Has the project phase changed?
+4. **Make it more specific** - Tighter scope is usually better
+
+## Implementation
+
+To review your rejected proposals, list the files in the rejected directory:
+
+```bash
+# List rejected proposals for your proposer type
+PROPOSER="${AGENT_NAME}"
+ls -la .orchestrator/shared/proposals/rejected/ 2>/dev/null | grep "${PROPOSER}" || echo "No rejections found"
+
+# Or list all rejected proposals
+ls -la .orchestrator/shared/proposals/rejected/
+
+# Read a specific rejection
+cat ".orchestrator/shared/proposals/rejected/PROP-abc12345.md"
+```
+
+To find rejections mentioning your proposer name:
+
+```bash
+grep -l "Proposer.*${AGENT_NAME}" .orchestrator/shared/proposals/rejected/*.md 2>/dev/null
+```
+
+## Best Practices
+
+1. **Review rejections at the start** of every proposer run
+2. **Learn from patterns** - If multiple proposals fail for similar reasons, adjust your approach
+3. **Don't spam** - Quality over quantity
+4. **Acknowledge feedback** - If re-proposing, note that you addressed previous feedback

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,101 @@
+# Code Review Guide
+
+You are reviewing code. Follow these guidelines to provide constructive feedback.
+
+## Review Process
+
+1. **Understand the context** - Read the task/PR description
+2. **Review the changes** - Examine each modified file
+3. **Provide feedback** - Be specific and constructive
+
+## What to Look For
+
+### Correctness
+- [ ] Does the code do what it's supposed to?
+- [ ] Are edge cases handled?
+- [ ] Is the logic correct?
+
+### Security (OWASP Top 10)
+- [ ] **Injection** - SQL, command, XSS vulnerabilities?
+- [ ] **Broken Auth** - Authentication/session issues?
+- [ ] **Sensitive Data** - Exposed credentials, PII leaks?
+- [ ] **XXE** - XML external entity attacks?
+- [ ] **Access Control** - Unauthorized access possible?
+- [ ] **Misconfiguration** - Insecure defaults?
+- [ ] **XSS** - User input reflected unsafely?
+- [ ] **Deserialization** - Unsafe object handling?
+- [ ] **Components** - Vulnerable dependencies?
+- [ ] **Logging** - Insufficient monitoring?
+
+### Code Quality
+- [ ] Is the code readable and maintainable?
+- [ ] Does it follow project conventions?
+- [ ] Are names meaningful?
+- [ ] Is there unnecessary complexity?
+- [ ] Is there code duplication?
+
+### Error Handling
+- [ ] Are errors handled appropriately?
+- [ ] Are error messages helpful?
+- [ ] Are edge cases covered?
+
+### Performance
+- [ ] Any obvious performance issues?
+- [ ] N+1 queries?
+- [ ] Unnecessary computations?
+- [ ] Memory leaks?
+
+### Testing
+- [ ] Are there tests for new functionality?
+- [ ] Do tests cover edge cases?
+- [ ] Are tests meaningful (not just for coverage)?
+
+## Providing Feedback
+
+### Be Constructive
+- Focus on the code, not the person
+- Explain why something is an issue
+- Suggest improvements
+
+### Examples
+
+**Good:**
+> This loop could be simplified using `map()`:
+> ```python
+> results = [process(item) for item in items]
+> ```
+
+**Avoid:**
+> This code is messy and hard to read.
+
+### Severity Levels
+- **Blocker** - Must fix before merge (security, major bugs)
+- **Major** - Should fix (logic issues, poor patterns)
+- **Minor** - Nice to fix (style, minor improvements)
+- **Suggestion** - Optional improvements
+
+## Using GitHub CLI
+
+```bash
+# View PR changes
+gh pr diff 123
+
+# Leave a review
+gh pr review 123 --approve
+gh pr review 123 --request-changes --body "feedback"
+gh pr review 123 --comment --body "feedback"
+
+# Add line comments
+gh api repos/{owner}/{repo}/pulls/123/comments \
+  -f body="Comment" \
+  -f path="file.py" \
+  -f line=42 \
+  -f side="RIGHT"
+```
+
+## Remember
+
+- You are in READ-ONLY mode
+- Do not modify any files
+- Focus on being helpful
+- Acknowledge good code too

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,0 +1,87 @@
+# Testing Guide
+
+You are running tests or adding test coverage. Follow these guidelines:
+
+## Understanding the Test Environment
+
+1. **Identify the test framework** - look for pytest, jest, mocha, etc.
+2. **Find existing tests** - understand the patterns used
+3. **Check for test configuration** - look for config files
+
+## Running Tests
+
+### Common Commands
+```bash
+# Python/pytest
+pytest
+pytest -v  # verbose
+pytest path/to/test_file.py  # specific file
+pytest -k "test_name"  # specific test
+
+# JavaScript/Node
+npm test
+npm run test:coverage
+
+# Go
+go test ./...
+go test -v ./path/to/package
+```
+
+### Interpreting Results
+- Read failure messages carefully
+- Check for stack traces
+- Note which tests pass vs fail
+
+## Writing Tests
+
+### Test Structure
+```
+Arrange - Set up test data and conditions
+Act - Execute the code being tested
+Assert - Verify the expected outcome
+```
+
+### Good Test Characteristics
+- **Isolated** - tests don't depend on each other
+- **Deterministic** - same result every time
+- **Fast** - quick to run
+- **Readable** - clear what's being tested
+
+### What to Test
+- Happy path (normal operation)
+- Edge cases (empty inputs, boundaries)
+- Error conditions (invalid inputs, failures)
+- Integration points (API calls, database)
+
+### Naming Conventions
+```python
+# Python
+def test_function_name_condition_expected_result():
+    pass
+
+# Example
+def test_calculate_total_with_discount_returns_reduced_price():
+    pass
+```
+
+```javascript
+// JavaScript
+describe('function name', () => {
+  it('should expected behavior when condition', () => {
+    // test
+  });
+});
+```
+
+## Coverage
+
+- Aim for meaningful coverage, not 100%
+- Focus on critical paths and complex logic
+- Don't test trivial getters/setters
+
+## Remember
+
+- You can only modify test files
+- Do not change production code
+- Document any bugs or issues found
+- Report test results clearly


### PR DESCRIPTION
## Summary
- Add 11 new slash commands for agents to participate in the orchestrator workflow
- Commands include: create-proposal, create-task, defer-proposal, escalate-conflict, implement, promote-proposal, record-check, reject-proposal, review-rejections, review, test

## Test plan
- [ ] Verify slash commands are loaded correctly by Claude Code
- [ ] Test create-proposal and create-task commands in agent context
- [ ] Verify review and implement guides are accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)