### PR TITLE
Fix safe area gap on extended open edges

### DIFF
--- a/tests/integration/geometry/safeSpace.test.ts
+++ b/tests/integration/geometry/safeSpace.test.ts
@@ -681,13 +681,9 @@ describe('Safe Space Computation', () => {
         expect(bodyMinY).toBeCloseTo(-halfH + 2 * mt, 0.1);
 
         // Top edge of body region:
-        // BUG: Currently stops at body edge (halfH = 50) but should extend
-        // all the way through to the extension outer edge (halfH + 20 = 70)
-        // since the top edge is open (no joint).
-        //
-        // This test documents the current buggy behavior where the body region
-        // stops at the original panel edge, creating a gap.
-        expect(bodyMaxY).toBeCloseTo(halfH, 0.1); // BUG: Stops at body edge
+        // FIX: Now extends all the way through to the extension outer edge
+        // (halfH + 20 = 70) since the top edge is open (no joint).
+        expect(bodyMaxY).toBeCloseTo(halfH + 20, 0.1); // Extends to outer edge (open)
       }
     });
 


### PR DESCRIPTION
## Summary
- Fixed bug where safe space calculation created a gap between body and extension regions on open edges
- The gap was caused by unconditionally adding MT margin between body and extension, even when the edge had no joints
- Now correctly extends the body safe region directly into the extension for open edges (contiguous, no gap)
- Jointed edges still have separate regions with MT gap (correct behavior)

## Test plan
- [x] All 22 safe space tests pass
- [x] Full test suite passes (764 tests)
- [x] Tests specifically verify:
  - Safe area extends to extended outer edge with NO margin on open edges
  - Safe area is ONE contiguous region from body through extension
  - Only jointed edges have margins

🤖 Generated with [Claude Code](https://claude.com/claude-code)