### PR TITLE
Add shape helper functions for test fixtures

### DIFF
--- a/src/test/fixtures/shapes.test.ts
+++ b/src/test/fixtures/shapes.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { rect, polygon, circle, lShape } from './shapes';
+
+describe('Shape helpers', () => {
+  describe('rect', () => {
+    it('creates rectangle with 4 points', () => {
+      const shape = rect(10, 20, 30, 40);
+      expect(shape.points).toBe(4);
+
+      const path = shape.toPath();
+      expect(path).toHaveLength(4);
+      expect(path[0]).toEqual({ x: 10, y: 20 });
+      expect(path[1]).toEqual({ x: 40, y: 20 });
+      expect(path[2]).toEqual({ x: 40, y: 60 });
+      expect(path[3]).toEqual({ x: 10, y: 60 });
+    });
+  });
+
+  describe('polygon', () => {
+    it('creates polygon from points', () => {
+      const shape = polygon([0, 0], [10, 0], [5, 10]);
+      expect(shape.points).toBe(3);
+
+      const path = shape.toPath();
+      expect(path).toHaveLength(3);
+      expect(path[0]).toEqual({ x: 0, y: 0 });
+      expect(path[1]).toEqual({ x: 10, y: 0 });
+      expect(path[2]).toEqual({ x: 5, y: 10 });
+    });
+  });
+
+  describe('circle', () => {
+    it('creates circle with default segments', () => {
+      const shape = circle(0, 0, 10);
+      expect(shape.points).toBe(16);
+
+      const path = shape.toPath();
+      expect(path).toHaveLength(16);
+
+      // First point should be at (10, 0) - rightmost
+      expect(path[0].x).toBeCloseTo(10);
+      expect(path[0].y).toBeCloseTo(0);
+    });
+
+    it('creates circle with custom segments', () => {
+      const shape = circle(5, 5, 10, 8);
+      expect(shape.points).toBe(8);
+    });
+  });
+
+  describe('lShape', () => {
+    it('creates L-shape with 6 points', () => {
+      const shape = lShape(0, 0, 20, 20, 10, 10);
+      expect(shape.points).toBe(6);
+
+      const path = shape.toPath();
+      expect(path).toHaveLength(6);
+    });
+  });
+});

--- a/src/test/fixtures/shapes.ts
+++ b/src/test/fixtures/shapes.ts
@@ -1,0 +1,91 @@
+import type { Point2D } from '../../engine/types';
+
+/**
+ * Shape interface for test fixtures.
+ * Shapes can be converted to paths and track their corner count.
+ */
+export interface Shape {
+  /** Convert shape to array of points for path operations */
+  toPath(): Point2D[];
+  /** Number of corners/points (for eligibility calculations) */
+  points: number;
+}
+
+/**
+ * Create a rectangle shape.
+ * @param x - Left edge X coordinate
+ * @param y - Bottom edge Y coordinate
+ * @param width - Width of rectangle
+ * @param height - Height of rectangle
+ */
+export function rect(x: number, y: number, width: number, height: number): Shape {
+  return {
+    toPath: () => [
+      { x, y },
+      { x: x + width, y },
+      { x: x + width, y: y + height },
+      { x, y: y + height },
+    ],
+    points: 4,
+  };
+}
+
+/**
+ * Create a polygon shape from points.
+ * @param points - Array of [x, y] tuples
+ */
+export function polygon(...points: [number, number][]): Shape {
+  return {
+    toPath: () => points.map(([x, y]) => ({ x, y })),
+    points: points.length,
+  };
+}
+
+/**
+ * Create a circle approximation (regular polygon).
+ * @param cx - Center X
+ * @param cy - Center Y
+ * @param radius - Radius
+ * @param segments - Number of segments (default 16)
+ */
+export function circle(cx: number, cy: number, radius: number, segments: number = 16): Shape {
+  const pts: Point2D[] = [];
+  for (let i = 0; i < segments; i++) {
+    const angle = (i / segments) * Math.PI * 2;
+    pts.push({
+      x: cx + Math.cos(angle) * radius,
+      y: cy + Math.sin(angle) * radius,
+    });
+  }
+  return {
+    toPath: () => pts,
+    points: segments,
+  };
+}
+
+/**
+ * Create an L-shaped polygon.
+ * Useful for testing non-rectangular cutouts.
+ */
+export function lShape(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  notchWidth: number,
+  notchHeight: number
+): Shape {
+  // L-shape: rectangle with top-right corner cut out
+  const pts: Point2D[] = [
+    { x, y },
+    { x: x + width, y },
+    { x: x + width, y: y + height - notchHeight },
+    { x: x + width - notchWidth, y: y + height - notchHeight },
+    { x: x + width - notchWidth, y: y + height },
+    { x, y: y + height },
+  ];
+  return {
+    toPath: () => pts,
+    points: 6,
+  };
+}


### PR DESCRIPTION
## Summary

- Add `Shape` interface for test fixtures with `toPath()` and `points` property
- Implement `rect()` helper for creating rectangular shapes
- Implement `polygon()` helper for arbitrary polygons from point tuples
- Implement `circle()` helper for circle approximations with configurable segments
- Implement `lShape()` helper for L-shaped polygons (non-rectangular cutout tests)

This is part of TASK-test-fixtures-1-3 in the composable test fixtures rollout. These shape helpers will be used with `PanelBuilder.withCutout(shape)` to define cutout and path shapes in tests.

## Test plan

- [x] All 5 unit tests pass for shape helpers
- [x] `rect(10, 10, 20, 20).toPath()` returns 4 points in correct order
- [x] `rect(...).points` equals 4
- [x] `polygon([0,0], [10,0], [5,10])` creates 3-point shape
- [x] `circle(0, 0, 10)` creates 16-point approximation by default
- [x] `circle(0, 0, 10, 8).points` equals 8
- [x] `lShape(...)` creates 6-point L-shaped polygon

🤖 Generated with [Claude Code](https://claude.com/claude-code)