### PR TITLE
[test-fixtures-1-4] Create Permutation Generator

### DIFF
--- a/src/test/fixtures/permute.test.ts
+++ b/src/test/fixtures/permute.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Tests for permutation utilities.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { permute, permuteNamed, countPermutations } from './permute';
+
+describe('permute', () => {
+  it('generates cartesian product', () => {
+    const result = permute({
+      a: [1, 2],
+      b: ['x', 'y'],
+    });
+
+    expect(result).toHaveLength(4);
+
+    // Check all combinations exist
+    const configs = result.map(([_, config]) => config);
+    expect(configs).toContainEqual({ a: 1, b: 'x' });
+    expect(configs).toContainEqual({ a: 1, b: 'y' });
+    expect(configs).toContainEqual({ a: 2, b: 'x' });
+    expect(configs).toContainEqual({ a: 2, b: 'y' });
+  });
+
+  it('handles arrays as values', () => {
+    const result = permute({
+      edges: [[], ['top'], ['top', 'left']],
+    });
+
+    expect(result).toHaveLength(3);
+    expect(result[0][1].edges).toEqual([]);
+    expect(result[1][1].edges).toEqual(['top']);
+    expect(result[2][1].edges).toEqual(['top', 'left']);
+  });
+
+  it('generates readable names', () => {
+    const result = permute({
+      count: [0, 1],
+    });
+
+    expect(result[0][0]).toContain('count=0');
+    expect(result[1][0]).toContain('count=1');
+  });
+
+  it('handles single dimension', () => {
+    const result = permute({
+      value: [1, 2, 3],
+    });
+
+    expect(result).toHaveLength(3);
+  });
+
+  it('handles empty arrays', () => {
+    const result = permute({
+      a: [],
+    });
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('shows array length in name for non-empty arrays', () => {
+    const result = permute({
+      items: [['a', 'b', 'c']],
+    });
+
+    expect(result[0][0]).toContain('items=[3 items]');
+  });
+
+  it('shows empty array notation in name', () => {
+    const result = permute({
+      items: [[]],
+    });
+
+    expect(result[0][0]).toContain('items=[]');
+  });
+
+  it('handles multiple dimensions', () => {
+    const result = permute({
+      a: [1, 2],
+      b: ['x', 'y'],
+      c: [true, false],
+    });
+
+    // 2 x 2 x 2 = 8 combinations
+    expect(result).toHaveLength(8);
+
+    // Verify first and last
+    expect(result[0][1]).toEqual({ a: 1, b: 'x', c: true });
+    expect(result[7][1]).toEqual({ a: 2, b: 'y', c: false });
+  });
+});
+
+describe('permuteNamed', () => {
+  it('uses custom name function', () => {
+    const result = permuteNamed(
+      { edges: [[], ['top']] },
+      (config) => `${config.edges.length} extensions`
+    );
+
+    expect(result[0][0]).toBe('0 extensions');
+    expect(result[1][0]).toBe('1 extensions');
+  });
+
+  it('generates same configs as permute', () => {
+    const config = { a: [1, 2], b: ['x', 'y'] };
+    const named = permuteNamed(config, (c) => `a=${c.a}, b=${c.b}`);
+    const basic = permute(config);
+
+    // Same length
+    expect(named).toHaveLength(basic.length);
+
+    // Same configs (just different names)
+    const namedConfigs = named.map(([_, c]) => c);
+    const basicConfigs = basic.map(([_, c]) => c);
+
+    for (const cfg of namedConfigs) {
+      expect(basicConfigs).toContainEqual(cfg);
+    }
+  });
+
+  it('can use config values in name', () => {
+    const result = permuteNamed(
+      { width: [100, 200], height: [50] },
+      (config) => `${config.width}x${config.height}`
+    );
+
+    expect(result[0][0]).toBe('100x50');
+    expect(result[1][0]).toBe('200x50');
+  });
+});
+
+describe('countPermutations', () => {
+  it('counts without generating', () => {
+    expect(countPermutations({ a: [1, 2], b: [1, 2, 3] })).toBe(6);
+    expect(countPermutations({ a: [1, 2, 3, 4, 5] })).toBe(5);
+  });
+
+  it('returns 1 for empty config', () => {
+    expect(countPermutations({})).toBe(1);
+  });
+
+  it('returns 0 when any array is empty', () => {
+    expect(countPermutations({ a: [], b: [1, 2] })).toBe(0);
+  });
+
+  it('handles large combinations', () => {
+    // 10 x 10 x 10 = 1000
+    const largeConfig = {
+      a: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      b: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+      c: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    };
+    expect(countPermutations(largeConfig)).toBe(1000);
+  });
+});
+
+describe('integration with describe.each', () => {
+  const matrix = permute({
+    value: [1, 2],
+  });
+
+  // This actually uses describe.each
+  describe.each(matrix)('with %s', (name, { value }) => {
+    it('has access to config', () => {
+      expect(value).toBeGreaterThan(0);
+    });
+
+    it('name is a string', () => {
+      expect(typeof name).toBe('string');
+    });
+  });
+
+  // Test with multiple dimensions
+  const matrix2 = permute({
+    width: [100, 200],
+    height: [50],
+  });
+
+  describe.each(matrix2)('dimensions: %s', (_, config) => {
+    it('has both dimensions', () => {
+      expect(config.width).toBeDefined();
+      expect(config.height).toBeDefined();
+    });
+  });
+});

--- a/src/test/fixtures/permute.ts
+++ b/src/test/fixtures/permute.ts
@@ -1,0 +1,128 @@
+/**
+ * Permutation utilities for matrix-driven testing.
+ *
+ * This module provides functions to generate all combinations of configuration
+ * options for use with vitest's `describe.each()` and `it.each()` patterns.
+ *
+ * @example
+ * ```typescript
+ * const matrix = permute({
+ *   extensions: [[], ['top'], ['top', 'left']],
+ *   cutouts: [[], [rect(10, 10, 20, 20)]],
+ * });
+ * // Returns 6 combinations (3 × 2)
+ *
+ * describe.each(matrix)('test: %s', (name, config) => {
+ *   it('works', () => {
+ *     // config.extensions and config.cutouts available
+ *   });
+ * });
+ * ```
+ */
+
+/**
+ * Configuration object where each key maps to an array of possible values.
+ */
+export type PermutationConfig = Record<string, unknown[]>;
+
+/**
+ * Result type: array of [name, config] tuples for use with describe.each()
+ */
+export type PermutationResult<T extends PermutationConfig> = Array<
+  [string, { [K in keyof T]: T[K][number] }]
+>;
+
+/**
+ * Generate all permutations (cartesian product) of configuration options.
+ *
+ * @example
+ * const matrix = permute({
+ *   extensions: [[], ['top'], ['top', 'left']],
+ *   cutouts: [[], [rect(10, 10, 20, 20)]],
+ * });
+ * // Returns 6 combinations (3 × 2)
+ *
+ * describe.each(matrix)('test: %s', (name, config) => {
+ *   it('works', () => {
+ *     // config.extensions and config.cutouts available
+ *   });
+ * });
+ */
+export function permute<T extends PermutationConfig>(config: T): PermutationResult<T> {
+  const keys = Object.keys(config) as (keyof T)[];
+  const results: PermutationResult<T> = [];
+
+  function generate(index: number, current: Partial<{ [K in keyof T]: T[K][number] }>) {
+    if (index === keys.length) {
+      // Build human-readable name
+      const name = keys
+        .map((k) => {
+          const value = current[k];
+          const valueStr = Array.isArray(value)
+            ? value.length === 0
+              ? '[]'
+              : `[${value.length} items]`
+            : JSON.stringify(value);
+          return `${String(k)}=${valueStr}`;
+        })
+        .join(', ');
+
+      results.push([name, { ...current } as { [K in keyof T]: T[K][number] }]);
+      return;
+    }
+
+    const key = keys[index];
+    const values = config[key];
+    for (const value of values) {
+      generate(index + 1, { ...current, [key]: value });
+    }
+  }
+
+  generate(0, {});
+  return results;
+}
+
+/**
+ * Generate named permutations with custom name function.
+ *
+ * @example
+ * const matrix = permuteNamed({
+ *   edges: [[], ['top'], ['top', 'left']],
+ * }, (config) => `${config.edges.length} extensions`);
+ */
+export function permuteNamed<T extends PermutationConfig>(
+  config: T,
+  nameFn: (config: { [K in keyof T]: T[K][number] }) => string
+): PermutationResult<T> {
+  const keys = Object.keys(config) as (keyof T)[];
+  const results: PermutationResult<T> = [];
+
+  function generate(index: number, current: Partial<{ [K in keyof T]: T[K][number] }>) {
+    if (index === keys.length) {
+      const fullConfig = { ...current } as { [K in keyof T]: T[K][number] };
+      results.push([nameFn(fullConfig), fullConfig]);
+      return;
+    }
+
+    const key = keys[index];
+    const values = config[key];
+    for (const value of values) {
+      generate(index + 1, { ...current, [key]: value });
+    }
+  }
+
+  generate(0, {});
+  return results;
+}
+
+/**
+ * Count total permutations without generating them.
+ */
+export function countPermutations(config: PermutationConfig): number {
+  const keys = Object.keys(config);
+  let result = 1;
+  for (const key of keys) {
+    result *= config[key].length;
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary

Automated implementation for task [test-fixtures-1-4].

## Task

Create Permutation Generator

## Changes

## Summary

I've successfully implemented the permutation generator for matrix-driven testing. Here's what was created:

### Files Created

1. **`src/test/fixtures/permute.ts`** - Contains three functions:
   - `permute(config)` - Generates cartesian product of all configuration combinations with auto-generated human-readable names (e.g., `"a=1, b='x'"`)
   - `permuteNamed(config, nameFn)` - Same as permute but allows custom naming function
   - `countPermutations(config)` - Counts total combinations without generating them

2. **`src/test/fixtures/permute.test.ts`** - 21 tests covering:
   - Cartesian product generation
   - Arrays as values (e.g., `edges: [[], ['top'], ['top', 'left']]`)
   - Readable name generation
   - Single and multiple dimensions
   - Empty arrays
   - Custom naming with `permuteNamed()`
   - Integration with vitest's `describe.each()`

### Acceptance Criteria Met

- ✅ `permute({ a: [1, 2], b: ['x', 'y'] })` returns 4 combinations
- ✅ Each result is `[name, config]` tuple
- ✅ Name is human-readable (e.g., "a=1, b='x'" or "items=[3 items]" for arrays)
- ✅ Works with `describe.each()` in vitest (tested in integration test)
- ✅ `permuteNamed()` allows custom naming
- ✅ `countPermutations()` returns total without generating

### Commit

`512e200` - "Add permutation generator for matrix-driven testing"


---
Generated by orchestrator agent: impl-agent-1
