### PR TITLE
[fillet-fix-008b] Fix: Detect corners from edge extensions and cutouts

### DIFF
--- a/src/engine/nodes/BasePanel.ts
+++ b/src/engine/nodes/BasePanel.ts
@@ -401,9 +401,16 @@ export abstract class BasePanel extends BaseNode {
       minEdgeLength: 2, // Minimum edge length to consider
     };
 
+    // Extract holes from the outline to pass to corner detection
+    // Each hole contributes corners that may be eligible for filleting
+    const holes = (outline.holes ?? []).map((hole, index) => ({
+      id: hole.id ?? `hole-${index}`,
+      path: hole.path,
+    }));
+
     const corners = detectAllPanelCorners(
       outline.points,
-      [], // No holes for now
+      holes,
       config
     );
 


### PR DESCRIPTION
## Summary

Automated implementation for task [fillet-fix-008b].

## Task

Fix: Detect corners from edge extensions and cutouts

## Changes

## Summary

I've completed task TASK-fillet-fix-008b. The fix was straightforward:

**Bug:** In `BasePanel.getAllCornerEligibility()`, the `detectAllPanelCorners()` function was being called with an empty array `[]` for holes instead of the actual holes from the computed outline.

**Fix:** Extract holes from `outline.holes` and map them to the format expected by `detectAllPanelCorners()`:

```typescript
const holes = (outline.holes ?? []).map((hole, index) => ({
  id: hole.id ?? `hole-${index}`,
  path: hole.path,
}));

const corners = detectAllPanelCorners(outline.points, holes, config);
```

**Verification:**
- The test "should show cutout corners as eligible when not in forbidden area" now correctly detects 4 hole corners from a rectangular cutout
- All 4 hole corners are marked as eligible (because the cutout is in the center, away from finger joint forbidden areas)
- Existing tests still pass

**Note:** There are still some pre-existing test failures related to finger joint corners being incorrectly marked as eligible (Bug 007), but that's a separate issue from this task. This fix specifically addresses the detection of cutout corners which was broken due to the empty array being passed.


---
Generated by orchestrator agent: impl-agent-2
