### PR TITLE
[fillet-fix-008a] Fix: Check both adjacent edges for corner eligibility

### DIFF
--- a/src/engine/nodes/BasePanel.ts
+++ b/src/engine/nodes/BasePanel.ts
@@ -413,8 +413,10 @@ export abstract class BasePanel extends BaseNode {
     const forbiddenAreas: ForbiddenArea[] = [];
 
     for (const status of edgeStatuses) {
-      if (status.status === 'locked') {
-        // Locked edges have finger joints - mark the entire edge region as forbidden
+      // Both 'locked' (male joints/tabs) and 'outward-only' (female joints/slots) edges have finger joints
+      // Corners at edges with any type of finger joints cannot be filleted
+      if (status.status === 'locked' || status.status === 'outward-only') {
+        // Edges with finger joints - mark the entire edge region as forbidden
         // Convert edge position to bounds
         let bounds: { minX: number; maxX: number; minY: number; maxY: number };
         const w = dims.width / 2;


### PR DESCRIPTION
## Summary

Automated implementation for task [fillet-fix-008a].

## Task

Fix: Check both adjacent edges for corner eligibility

## Changes

## Summary

I've successfully fixed bug 008A: **Corners are marked eligible when only ONE adjacent edge is open**.

### Root Cause
The `getAllCornerEligibility()` method in `BasePanel.ts` was only creating forbidden areas for edges with `'locked'` status (male finger joints/tabs). Edges with `'outward-only'` status (female finger joints/slots) were not considered forbidden, which meant corners could be incorrectly marked as eligible when only one adjacent edge was open.

### Fix Applied
Changed the condition in `getAllCornerEligibility()` from:
```typescript
if (status.status === 'locked') {
```
to:
```typescript
if (status.status === 'locked' || status.status === 'outward-only') {
```

### Test Results
- **Closed box panels** (all edges have finger joints): **0 eligible corners** ✓
- **Panels with two open edges** (top + left faces disabled): **1 eligible corner** ✓

The fix ensures that corners are only marked eligible for filleting when BOTH adjacent edges are completely free of finger joints (i.e., both have 'unlocked' status from disabled/open adjacent faces).

### Commit
The fix was committed as `89a1305` on branch `agent/fillet-fix-008a-20260204-215500`.


---
Generated by orchestrator agent: impl-agent-2
