### PR TITLE
[7fc656ad] Extend SerializedState interface for panel operations

### DIFF
--- a/src/utils/urlState.ts
+++ b/src/utils/urlState.ts
@@ -16,6 +16,7 @@ interface SerializedState {
   f: number;  // Faces bitmap (6 bits, one per face)
   r: SerializedVoid;  // Root void
   e?: Record<string, [number, number, number, number]>;  // Edge extensions by panel ID [top, bottom, left, right]
+  po?: Record<string, SerializedPanelOps>;  // Panel operations by panel ID (fillets, cutouts)
 }
 
 interface SerializedAssembly {
@@ -37,6 +38,43 @@ interface SerializedSubAssembly {
 interface SerializedGridSubdivision {
   ax: ('x' | 'y' | 'z')[];  // axes
   pos: Partial<Record<'x' | 'y' | 'z', number[]>>;  // positions per axis
+}
+
+// =============================================================================
+// Panel Operations Serialization
+// =============================================================================
+
+/**
+ * Serialized cutout shape with compact field names.
+ * - t: type ('r' = rect, 'c' = circle, 'p' = path)
+ * - cx, cy: center position
+ * - w, h: width, height (rect only)
+ * - cr: corner radius (rect only, optional)
+ * - r: radius (circle only)
+ * - pt: points array (path only)
+ * - m: mode ('a' = additive, 's' = subtractive, default subtractive)
+ */
+interface SerializedCutout {
+  id: string;
+  t: 'r' | 'c' | 'p';  // type: rect, circle, path
+  cx: number;          // center.x
+  cy: number;          // center.y
+  w?: number;          // width (rect)
+  h?: number;          // height (rect)
+  cr?: number;         // cornerRadius (rect, optional)
+  r?: number;          // radius (circle)
+  pt?: [number, number][];  // points (path) as [x, y] tuples
+  m?: 'a' | 's';       // mode: additive, subtractive (default)
+}
+
+/**
+ * Serialized panel operations with compact field names.
+ * Key is panel ID, contains all operations applied to that panel.
+ */
+interface SerializedPanelOps {
+  cf?: Record<string, number>;  // cornerFillets: cornerKey (e.g., 'bottom:left') → radius
+  acf?: Record<string, number>; // allCornerFillets: cornerId (e.g., 'outline:5') → radius
+  co?: SerializedCutout[];      // cutouts array
 }
 
 interface SerializedVoid {


### PR DESCRIPTION
## Summary

Automated implementation for task [7fc656ad].

## Task

Extend SerializedState interface for panel operations

## Changes

The task is complete. Here's a summary of what was implemented:

## Summary

I extended the `SerializedState` interface in `/src/utils/urlState.ts` to support panel operations serialization:

### New Interfaces Added

1. **`SerializedCutout`** - Compact representation of cutout shapes:
   - `id`: Unique identifier
   - `t`: Type ('r' = rect, 'c' = circle, 'p' = path)
   - `cx`, `cy`: Center position
   - `w`, `h`: Width/height (rect only)
   - `cr`: Corner radius (rect, optional)
   - `r`: Radius (circle only)
   - `pt`: Points as `[x, y]` tuples (path only)
   - `m`: Mode ('a' = additive, 's' = subtractive, default)

2. **`SerializedPanelOps`** - Panel operations container:
   - `cf`: Corner fillets (cornerKey → radius)
   - `acf`: All-corner fillets (cornerId → radius)
   - `co`: Array of cutouts

3. **`SerializedState.po`** - Optional field added:
   - Maps panel ID to `SerializedPanelOps`
   - Follows existing compact naming convention (`po` like `e` for edge extensions)

### Acceptance Criteria Met
- ✅ SerializedState interface has optional `po` field for panel operations
- ✅ SerializedPanelOps interface defined with cf, acf, co fields
- ✅ SerializedCutout type defined with compact field names
- ✅ TypeScript compiles without new errors (pre-existing unused variable warnings are unrelated)


---
Generated by orchestrator agent: impl-agent-1
