### PR TITLE
[78606c45] Fix void mesh transparency causing panels to disappear

### DIFF
--- a/src/components/VoidMesh.tsx
+++ b/src/components/VoidMesh.tsx
@@ -161,6 +161,7 @@ export const VoidMesh: React.FC<VoidMeshProps> = ({ voidId, bounds, boxCenter })
         <meshStandardMaterial
           color={isSelected ? colors.void.selected.base : isHovered ? colors.interactive.hover.base : colors.void.default.base}
           transparent
+          depthWrite={false}
           opacity={isSelected ? colors.opacity.default : isHovered ? colors.opacity.subtle : colors.opacity.faint}
         />
       </mesh>


### PR DESCRIPTION
## Summary

Automated implementation for task [78606c45].

## Task

Fix void mesh transparency causing panels to disappear

## Changes

Done. Here's a summary:

**Problem:** When a void was selected, its translucent mesh could occlude surrounding opaque panels at certain camera angles — a classic THREE.js transparency depth-sorting issue.

**Root Cause:** The `meshStandardMaterial` in `src/components/VoidMesh.tsx:161` had `transparent: true` but was missing `depthWrite: false`. This caused the transparent void mesh to write to the depth buffer, blocking opaque panels behind it.

**Fix:** Added `depthWrite={false}` to the void mesh material. This is one line — the standard fix for transparent objects in THREE.js. Transparent objects should read the depth buffer (to be correctly occluded by opaque objects in front) but should not write to it (to avoid occluding opaque objects behind them).

**Verification:** All 1092 tests pass, no new type errors. Commit: `be89cc7`.


---
Generated by orchestrator agent: impl-agent-1
