### PR TITLE
[251e9f63] 251e9f63

### DIFF
--- a/src/components/AssemblyAxisIndicator.tsx
+++ b/src/components/AssemblyAxisIndicator.tsx
@@ -16,8 +16,9 @@ interface AssemblyCenterLinesProps {
 const LINE_EXTENT = 10000;
 
 /**
- * Shows infinite center lines through the origin on all 3 axes (X/Y/Z).
- * Lines are thin, slightly transparent, and render through geometry
+ * Shows a single infinite vertical (Y-axis) center line through the origin.
+ * Indicates the top/bottom orientation axis of the assembly.
+ * The line is thin, slightly transparent, and renders through geometry
  * (not occluded by panels) using depthTest: false.
  */
 export const AssemblyCenterLines: React.FC<AssemblyCenterLinesProps> = ({
@@ -25,47 +26,21 @@ export const AssemblyCenterLines: React.FC<AssemblyCenterLinesProps> = ({
   opacity = 0.35,
 }) => {
   const colors = useColors();
-  const axisColors = colors.axis;
-
-  const lines = useMemo(() => {
-    return [
-      {
-        axis: 'x' as Axis,
-        start: [-LINE_EXTENT, 0, 0] as [number, number, number],
-        end: [LINE_EXTENT, 0, 0] as [number, number, number],
-        color: axisColors.x,
-      },
-      {
-        axis: 'y' as Axis,
-        start: [0, -LINE_EXTENT, 0] as [number, number, number],
-        end: [0, LINE_EXTENT, 0] as [number, number, number],
-        color: axisColors.y,
-      },
-      {
-        axis: 'z' as Axis,
-        start: [0, 0, -LINE_EXTENT] as [number, number, number],
-        end: [0, 0, LINE_EXTENT] as [number, number, number],
-        color: axisColors.z,
-      },
-    ];
-  }, [axisColors]);
 
   if (!visible) return null;
 
   return (
-    <group>
-      {lines.map(({ axis, start, end, color }) => (
-        <Line
-          key={axis}
-          points={[start, end]}
-          color={color}
-          lineWidth={1}
-          transparent
-          opacity={opacity}
-          depthTest={false}
-        />
-      ))}
-    </group>
+    <Line
+      points={[
+        [0, -LINE_EXTENT, 0] as [number, number, number],
+        [0, LINE_EXTENT, 0] as [number, number, number],
+      ]}
+      color={colors.axis.y}
+      lineWidth={1}
+      transparent
+      opacity={opacity}
+      depthTest={false}
+    />
   );
 };
 


### PR DESCRIPTION
## Summary

Automated implementation for task [251e9f63].

## Task

251e9f63

## Changes

Done. Here's a summary of what I implemented:

**Task:** TASK-251e9f63 — Replace axis arrow with infinite center lines (rejection fix)

**Problem:** QA rejected twice because the `AssemblyCenterLines` component showed center lines on all 3 axes (X/Y/Z), but the design intent was a single Y-axis vertical line indicating top/bottom orientation.

**Fix:** Simplified `AssemblyCenterLines` in `src/components/AssemblyAxisIndicator.tsx`:
- Removed the `useMemo` array with X, Y, Z line data
- Removed the `<group>` wrapper and `.map()` loop
- Now renders a single `<Line>` element for the Y-axis only, using the green Y-axis color
- No changes to `Box3D.tsx` — the component API (`visible`, `opacity`) is unchanged

**Verification:**
- All 1092 tests pass
- No new TypeScript errors
- Committed as `8a3ac0c` on branch `agent/251e9f63-20260209-130156`
- Pushed to origin


---
Generated by orchestrator agent: impl-agent-1
