### PR TITLE
[251e9f63] 251e9f63

### DIFF
--- a/src/components/AssemblyAxisIndicator.tsx
+++ b/src/components/AssemblyAxisIndicator.tsx
@@ -6,6 +6,8 @@ import { useColors } from '../hooks/useColors';
 type Axis = 'x' | 'y' | 'z';
 
 interface AssemblyCenterLinesProps {
+  /** The assembly axis to render the line on */
+  axis?: Axis;
   /** Whether to show the lines */
   visible?: boolean;
   /** Opacity of the lines */
@@ -15,13 +17,21 @@ interface AssemblyCenterLinesProps {
 // Large extent value to simulate "infinite" lines within the viewport
 const LINE_EXTENT = 10000;
 
+// Line endpoints for each axis
+const AXIS_POINTS: Record<Axis, [[number, number, number], [number, number, number]]> = {
+  x: [[-LINE_EXTENT, 0, 0], [LINE_EXTENT, 0, 0]],
+  y: [[0, -LINE_EXTENT, 0], [0, LINE_EXTENT, 0]],
+  z: [[0, 0, -LINE_EXTENT], [0, 0, LINE_EXTENT]],
+};
+
 /**
- * Shows a single infinite vertical (Y-axis) center line through the origin.
- * Indicates the top/bottom orientation axis of the assembly.
+ * Shows a single infinite center line through the origin on the assembly axis.
+ * Indicates the orientation axis of the assembly (e.g. top/bottom for Y).
  * The line is thin, slightly transparent, and renders through geometry
  * (not occluded by panels) using depthTest: false.
  */
 export const AssemblyCenterLines: React.FC<AssemblyCenterLinesProps> = ({
+  axis = 'y',
   visible = true,
   opacity = 0.35,
 }) => {
@@ -31,11 +41,8 @@ export const AssemblyCenterLines: React.FC<AssemblyCenterLinesProps> = ({
 
   return (
     <Line
-      points={[
-        [0, -LINE_EXTENT, 0] as [number, number, number],
-        [0, LINE_EXTENT, 0] as [number, number, number],
-      ]}
-      color={colors.axis.y}
+      points={AXIS_POINTS[axis]}
+      color={colors.axis[axis]}
       lineWidth={1}
       transparent
       opacity={opacity}

--- a/src/components/Box3D.tsx
+++ b/src/components/Box3D.tsx
@@ -124,7 +124,7 @@ export const Box3D: React.FC<Box3DProps> = ({ pushPullCallbacks }) => {
       {selectedAssemblyId != null && (() => {
         if (selectedAssemblyId === 'main') {
           // Main assembly: center lines at origin (center of box)
-          return <AssemblyCenterLines visible={true} />;
+          return <AssemblyCenterLines axis={config.assembly?.assemblyAxis ?? 'y'} visible={true} />;
         }
         // Sub-assembly: find its position and offset center lines
         const subInfo = subAssemblies.find(s => s.subAssembly.id === selectedAssemblyId);
@@ -139,7 +139,7 @@ export const Box3D: React.FC<Box3DProps> = ({ pushPullCallbacks }) => {
         const cz = (bounds.z + subAssembly.clearance - offsets.back + subOuterD / 2 - boxCenter.z) * scale;
         return (
           <group position={[cx, cy, cz]}>
-            <AssemblyCenterLines visible={true} />
+            <AssemblyCenterLines axis={subAssembly.assembly?.assemblyAxis ?? 'y'} visible={true} />
           </group>
         );
       })()}


### PR DESCRIPTION
## Summary

Automated implementation for task [251e9f63].

## Task

251e9f63

## Changes

## Summary

The task had been attempted 5 times previously, each time declaring "ALREADY_DONE" — but there was a real bug: `AssemblyCenterLines` was **hardcoded to always render on the Y-axis** regardless of the assembly's configured axis. The task requires the line to follow `config.assembly.assemblyAxis`, which defaults to Y but can be X or Z.

**What I fixed (commit `023a41d`):**

1. **`AssemblyAxisIndicator.tsx`** — Added an `axis` prop to `AssemblyCenterLines` with a lookup table (`AXIS_POINTS`) for line endpoints per axis, and dynamic color selection via `colors.axis[axis]`
2. **`Box3D.tsx`** — Pass the actual assembly axis from config for both main assembly (`config.assembly.assemblyAxis`) and sub-assemblies (`subAssembly.assembly.assemblyAxis`)

All 1092 tests pass with no regressions.


---
Generated by orchestrator agent: impl-agent-1
